### PR TITLE
vmmap in the right way

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ C:\Pin311\pin.exe -appdebug —appdebug_server_port 10000 -t bluepill32.dll -deb
 
 And connect to the desired port number. The application will stay paused until you connect a debugger, but if you instead attach one to the process you will end up debugging Pin and the JIT-ted code. For IDA Pro users select the *Remote GDB debugger* option and connect to `localhost`. To map missing memory segments you can use the `AddSegments.py` IDAPython script available in the `scripts/` folder: we defined a custom `vmmap` GDB command that gets invoked by the script and transfers memory layout information from the pintool to the debugger.
 
-Exception handling requires a workaround for the current GDB server implementation. When you need to pass an exception to the application just send a `wait` command right after you receive the exception message, then disconnect and reconnect IDA to BluePill, which meanwhile will put the execution on hold in response to the command.
+Exception handling requires a workaround for the current GDB server implementation. When you need to pass an exception to the application just send a `wait` [monitor command](https://www.hex-rays.com/products/ida/support/idadoc/1335.shtml) right after you receive the exception message, then disconnect and reconnect IDA to BluePill, which meanwhile will put the execution on hold in response to the command.
 
 P.S. Apologies for the incompleteness/minimalism in the documentation: we wanted to release the code as soon as possible while we keep working on the docs :-)

--- a/scripts/AddSegments.py
+++ b/scripts/AddSegments.py
@@ -19,15 +19,17 @@ try:
         name = os.path.basename(pathname)
         sclass = "DATA" # TODO recognize automatically sclass
         idaapi.add_segm(0, start, end, name, sclass)
-  			idc.set_segm_attr(start, SEGATTR_PERM, perms)
-			  idc.set_segm_attr(start, SEGATTR_ES, 0)
-			  idc.set_segm_attr(start, SEGATTR_CS, 0)
-			  idc.set_segm_attr(start, SEGATTR_SS, 0)
-			  idc.set_segm_attr(start, SEGATTR_DS, 0)
-			  idc.set_segm_attr(start, SEGATTR_FS, 0)
-			  idc.set_segm_attr(start, SEGATTR_GS, 0)
+        idc.set_segm_attr(start, SEGATTR_PERM, perms)
+        idc.set_segm_attr(start, SEGATTR_ES, 0)
+        idc.set_segm_attr(start, SEGATTR_CS, 0)
+        idc.set_segm_attr(start, SEGATTR_SS, 0)
+        idc.set_segm_attr(start, SEGATTR_DS, 0)
+        idc.set_segm_attr(start, SEGATTR_FS, 0)
+        idc.set_segm_attr(start, SEGATTR_GS, 0)
 except:
-	#self.AddLine(idaapi.COLSTR("Debugger is not active or does not export send_dbg_command()", idaapi.SCOLOR_ERROR))
-	print ("Debugger is not active or does not export send_dbg_command()")
+    #self.AddLine(idaapi.COLSTR("Debugger is not active or does not export send_dbg_command()", idaapi.SCOLOR_ERROR))
+    import traceback
+    traceback.print_exc()
+    print ("\nDebugger is not active or does not export send_dbg_command()")
 
 

--- a/scripts/AddSegments.py
+++ b/scripts/AddSegments.py
@@ -1,25 +1,33 @@
 import idaapi
+import json
 import idc
+import os
+
+SEG_PROT_R = 4
+SEG_PROT_W = 2
+SEG_PROT_X = 1
 
 cmd = 'vmmap'
 try:
-	r = idc.SendDbgCommand(cmd)#Eval('SendDbgCommand("%s");' % cmd).split("\n")
-	r = r.splitlines()
-	for s in r:
-		s = s.lstrip("[")
-		s = s.rstrip("]")
-		str = s.split(",")
-		if str[3].strip("\"") != "<no name>":
-			sn = str[3].split("\\")
-			idaapi.add_segm(0, int(str[0]), int(str[1]), sn[len(sn)-1], "DATA")
-			SetSegmentAttr(int(str[0]), SEGATTR_PERM, int(str[2]))
-			SetSegmentAttr(int(str[0]), SEGATTR_ES, 0)
-			SetSegmentAttr(int(str[0]), SEGATTR_CS, 0)
-			SetSegmentAttr(int(str[0]), SEGATTR_SS, 0)
-			SetSegmentAttr(int(str[0]), SEGATTR_DS, 0)
-			SetSegmentAttr(int(str[0]), SEGATTR_FS, 0)
-			SetSegmentAttr(int(str[0]), SEGATTR_GS, 0)
-			
+    mappings = json.loads(idc.send_dbg_command("vmmap"))
+    for start, end, prot, pathname in mappings:
+        # if pathname == "<no name>": continue # Why we should ignore mmapped mapges & co.?
+        perms = 0
+        if prot & SEG_PROT_R: perms |= idaapi.SEGPERM_READ
+        if prot & SEG_PROT_W: perms |= idaapi.SEGPERM_WRITE
+        if prot & SEG_PROT_X: perms |= idaapi.SEGPERM_EXEC
+        name = os.path.basename(pathname)
+        sclass = "DATA" # TODO recognize automatically sclass
+        idaapi.add_segm(0, start, end, name, sclass)
+  			idc.set_segm_attr(start, SEGATTR_PERM, perms)
+			  idc.set_segm_attr(start, SEGATTR_ES, 0)
+			  idc.set_segm_attr(start, SEGATTR_CS, 0)
+			  idc.set_segm_attr(start, SEGATTR_SS, 0)
+			  idc.set_segm_attr(start, SEGATTR_DS, 0)
+			  idc.set_segm_attr(start, SEGATTR_FS, 0)
+			  idc.set_segm_attr(start, SEGATTR_GS, 0)
 except:
-	#self.AddLine(idaapi.COLSTR("Debugger is not active or does not export SendDbgCommand()", idaapi.SCOLOR_ERROR))
-	print "Debugger is not active or does not export SendDbgCommand()"
+	#self.AddLine(idaapi.COLSTR("Debugger is not active or does not export send_dbg_command()", idaapi.SCOLOR_ERROR))
+	print ("Debugger is not active or does not export send_dbg_command()")
+
+


### PR DESCRIPTION
+ ugly camel case API is not supported in recent IDA versions. They were deprected in IDA 7.0 and abandoned later.
+ vmmap is intended to be parsed as a json. `json.loads(idc.send_dbg_command("vmmap"))` is better than hand crafted stuffs
+ idaapi.SEGPERM_* may not be consistent with the permissions in vmmap. idaapi.SEGPERM_* are the right constants, not SEG_PROT_*